### PR TITLE
Get neighborhood graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,9 @@ Graph API for Apache Flink
 ##Implemented Operations
 
 ###Graph Class
-
-* readTuple2CsvFile
-* readEdgesCsvFile
-* readGraphFromCsvFile
+* getNeighbors(vertexId)
+* getInNeighbors(vertexId)
+* getOutNeighbors(vertexId)
 
 ###Vertex Class
 
@@ -42,13 +41,13 @@ Graph API for Apache Flink
 * numberOfEdges()
 * getVertexIds()
 * getEdgeIds()
+* fromCollection(edges)
+* getNeighborhoodGraph(Vertex src, int distance)
+* vertexCentricComputation()
 
 ##Wishlist
 
 ###Graph Class
-* fromCollection(edges)
-* getNeighborhoodGraph(Vertex src, int distance)
-* vertexCentricComputation()
 * edgeCentricComputation()
 * partitionCentricComputation()
 
@@ -56,10 +55,6 @@ Graph API for Apache Flink
 * getDegree()
 * inDegree()
 * outDegree()
-* getInNeighbors()
-* getOutNeighbors()
-* getAllNeighbors()
-
 
 ###Edge Class
 

--- a/src/main/java/flink/graphs/Graph.java
+++ b/src/main/java/flink/graphs/Graph.java
@@ -10,8 +10,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,K extends Serializablr & Comparable, 
-    	VV implements Serializable, 
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -728,7 +727,7 @@ public class Graph<K extends Comparable<K> & Serializable, VV extends Serializab
      * @param vertexId
      * @return a dataset containing the neighboring vertices
      */
-    public DataSet<Tuple2<K, VV>> getNeighbors(K vertexId) {
+    public DataSet<Vertex<K, VV>> getNeighbors(K vertexId) {
     	// get neighbor ids
     	DataSet<Tuple1<K>> neighborIds = this.getEdges()
     			.filter(new FilterOnVertexId<K, VV, EV>(vertexId))
@@ -752,39 +751,39 @@ public class Graph<K extends Comparable<K> & Serializable, VV extends Serializab
     	
     	// if distance == 1: return the source vertex and its neighbors
     	if (distance == 1) {
-    		DataSet<Tuple2<K, VV>> sourceVertex = this.getVertices().filter(
+    		DataSet<Vertex<K, VV>> sourceVertex = this.getVertices().filter(
     				new SelectVertex<K, VV>(srcVertexId));
     		
-    		DataSet<Tuple2<K, VV>> sourceNeighbors = this.getNeighbors(srcVertexId);
+    		DataSet<Vertex<K, VV>> sourceNeighbors = this.getNeighbors(srcVertexId);
     		
     		return Graph.create(sourceVertex.union(sourceNeighbors), this.getEdges()
         			.filter(new FilterOnVertexId<K, VV, EV>(srcVertexId)), context);
     	}
 
     	// create iteration initial dataset: the neighboring edges of the src
-    	IterativeDataSet<Tuple3<K, K, EV>> initialEdges = this.getEdges()
+    	IterativeDataSet<Edge<K, EV>> initialEdges = this.getEdges()
     			.filter(new FilterOnVertexId<K, VV, EV>(srcVertexId)).iterate(distance-1);
     	
     	DataSet<Tuple1<K>> vertices = initialEdges
     			.flatMap(new ProjectVertexIdFromEdge<K, EV>()).distinct();
     	
-    	DataSet<Tuple3<K, K, EV>> outEdges = vertices
+    	DataSet<Edge<K, EV>> outEdges = vertices
     			.join(this.getEdges()).where(0).equalTo(0)
 				.with(new ProjectEdgeOnly<K, EV>());
     	
-    	DataSet<Tuple3<K, K, EV>> inEdges = vertices
+    	DataSet<Edge<K, EV>> inEdges = vertices
     			.join(this.getEdges()).where(0).equalTo(1)
 				.with(new ProjectEdgeOnly<K, EV>());
     	
-    	DataSet<Tuple3<K, K, EV>> allEdges = inEdges.union(outEdges).distinct();
+    	DataSet<Edge<K, EV>> allEdges = inEdges.union(outEdges).distinct();
 
     	// close the iteration
-    	DataSet<Tuple3<K, K, EV>> finalEdges = initialEdges.closeWith(allEdges);
+    	DataSet<Edge<K, EV>> finalEdges = initialEdges.closeWith(allEdges);
     	
     	DataSet<Tuple1<K>> finalVertexIds = finalEdges
     			.flatMap(new ProjectVertexIdFromEdge<K, EV>()).distinct();
     	
-    	DataSet<Tuple2<K, VV>> finalVertices = finalVertexIds.join(this.getVertices())
+    	DataSet<Vertex<K, VV>> finalVertices = finalVertexIds.join(this.getVertices())
     			.where(0).equalTo(0).with(new ProjectVertexOnly<K, VV>());
 
 		return Graph.create(finalVertices, finalEdges, context);
@@ -804,42 +803,42 @@ public class Graph<K extends Comparable<K> & Serializable, VV extends Serializab
     	
     	// if distance == 1: return the source vertex and its neighbors
     	if (distance == 1) {
-    		DataSet<Tuple2<K, VV>> sourceVertex = this.getVertices().filter(
+    		DataSet<Vertex<K, VV>> sourceVertex = this.getVertices().filter(
     				new SelectVertex<K, VV>(srcVertexId));
 
-    		DataSet<Tuple2<K, VV>> sourceNeighbors = this.getNeighbors(srcVertexId);
+    		DataSet<Vertex<K, VV>> sourceNeighbors = this.getNeighbors(srcVertexId);
     		
     		return Graph.create(sourceVertex.union(sourceNeighbors), this.getEdges()
         			.filter(new FilterOnVertexId<K, VV, EV>(srcVertexId)), context);
     	}
 
     	// create iteration initial dataset: the neighboring edges of the src
-    	DeltaIteration<Tuple3<K, K, EV>, Tuple1<K>> iteration = this.getEdges()
+    	DeltaIteration<Edge<K, EV>, Tuple1<K>> iteration = this.getEdges()
     			.filter(new FilterOnVertexId<K, VV, EV>(srcVertexId))
     			.iterateDelta(this.getNeighbors(srcVertexId)
     					.map(new ProjectVertexId<K, VV>()), distance-1, 0, 1);
 
-    	DataSet<Tuple3<K, K, EV>> intermediateOutEdges = iteration.getWorkset()
+    	DataSet<Edge<K, EV>> intermediateOutEdges = iteration.getWorkset()
     			.join(this.getEdges()).where(0).equalTo(0)
     			.with(new ProjectEdgeOnly<K, EV>());
     	
-    	DataSet<Tuple3<K, K, EV>> intermediateInEdges = iteration.getWorkset()
+    	DataSet<Edge<K, EV>> intermediateInEdges = iteration.getWorkset()
     			.join(this.getEdges()).where(0).equalTo(1)
     			.with(new ProjectEdgeOnly<K, EV>());
 
-    	DataSet<Tuple3<K, K, EV>> allNewEdges = intermediateInEdges.union(intermediateOutEdges)
+    	DataSet<Edge<K, EV>> allNewEdges = intermediateInEdges.union(intermediateOutEdges)
     			.distinct(); 
 
     	DataSet<Tuple1<K>> newVertexIds = allNewEdges.flatMap(new ProjectVertexIdFromEdge<K, EV>())
     			.distinct().coGroup(iteration.getWorkset())
     			.where(0).equalTo(0).with(new SetDifferenceCoGroup<K>(srcVertexId));
 
-    	DataSet<Tuple3<K, K, EV>> finalEdges = iteration.closeWith(allNewEdges, newVertexIds);
+    	DataSet<Edge<K, EV>> finalEdges = iteration.closeWith(allNewEdges, newVertexIds);
     	
     	DataSet<Tuple1<K>> finalVertexIds = finalEdges
     			.flatMap(new ProjectVertexIdFromEdge<K, EV>()).distinct();
     	
-    	DataSet<Tuple2<K, VV>> finalVertices = finalVertexIds.join(this.getVertices())
+    	DataSet<Vertex<K, VV>> finalVertices = finalVertexIds.join(this.getVertices())
     			.where(0).equalTo(0).with(new ProjectVertexOnly<K, VV>());
     	
     	return Graph.create(finalVertices, finalEdges, context);
@@ -874,36 +873,38 @@ public class Graph<K extends Comparable<K> & Serializable, VV extends Serializab
 		}
     }
 
-    private static final class ProjectVertexId<K, VV> implements MapFunction<
-    	Tuple2<K, VV>, Tuple1<K>> {
-		public Tuple1<K> map(Tuple2<K, VV> vertex) { 
+    private static final class ProjectVertexId<K extends Comparable<K> & Serializable, 
+    	VV extends Serializable> implements MapFunction<
+    	Vertex<K, VV>, Tuple1<K>> {
+		public Tuple1<K> map(Vertex<K, VV> vertex) { 
 			return new Tuple1<K>(vertex.f0);
 		}
     }
 
-    private static final class FilterOnVertexId<K, VV, EV> implements FilterFunction
-    	<Tuple3<K, K, EV>> {
+    private static final class FilterOnVertexId<K extends Comparable<K> & Serializable, 
+		VV extends Serializable, EV extends Serializable> implements FilterFunction
+    	<Edge<K, EV>> {
 
     	private K src;
     	private FilterOnVertexId(K sourceVertex) {
     		this.src = sourceVertex;
     	}
-			public boolean filter(Tuple3<K, K, EV> edge) {
+			public boolean filter(Edge<K, EV> edge) {
 				return ((edge.f0.equals(src)) || (edge.f1.equals(src)));
 			}
     }
     
-    private static final class ProjectVertexIdFromEdge<K, EV> implements FlatMapFunction<
-    	Tuple3<K,K,EV>, Tuple1<K>> {
+    private static final class ProjectVertexIdFromEdge<K extends Comparable<K> & Serializable, 
+		EV extends Serializable> implements FlatMapFunction<Edge<K, EV>, Tuple1<K>> {
 		
-    	public void flatMap(Tuple3<K, K, EV> edge, Collector<Tuple1<K>> out) {
+    	public void flatMap(Edge<K, EV> edge, Collector<Tuple1<K>> out) {
 			out.collect(new Tuple1<K>(edge.f0));
 			out.collect(new Tuple1<K>(edge.f1));
 		}
 	}
     
-    private static final class ProjectOtherVertexId<K, EV> implements FlatMapFunction<
-		Tuple3<K,K,EV>, Tuple1<K>> {
+    private static final class ProjectOtherVertexId<K extends Comparable<K> & Serializable, 
+		EV extends Serializable> implements FlatMapFunction<Edge<K, EV>, Tuple1<K>> {
 
     	private K thisVertexId;
     	
@@ -911,7 +912,7 @@ public class Graph<K extends Comparable<K> & Serializable, VV extends Serializab
     		this.thisVertexId = vertexId;
     	}
 	
-		public void flatMap(Tuple3<K, K, EV> edge, Collector<Tuple1<K>> out) {
+		public void flatMap(Edge<K, EV> edge, Collector<Tuple1<K>> out) {
 			if (edge.f0.equals(thisVertexId)) {
 				out.collect(new Tuple1<K>(edge.f1));
 			}
@@ -921,30 +922,33 @@ public class Graph<K extends Comparable<K> & Serializable, VV extends Serializab
 		}
     }
     
-    private static final class ProjectEdgeOnly<K, EV> implements FlatJoinFunction<
-    	Tuple1<K>, Tuple3<K,K,EV>, Tuple3<K,K,EV>> {
-		public void join(Tuple1<K> vertexId, Tuple3<K, K, EV> edge,
-				Collector<Tuple3<K, K, EV>> out) {
+    private static final class ProjectEdgeOnly<K extends Comparable<K> & Serializable, 
+	EV extends Serializable> implements FlatJoinFunction<
+    	Tuple1<K>, Edge<K,EV>, Edge<K, EV>> {
+		public void join(Tuple1<K> vertexId, Edge<K, EV> edge,
+				Collector<Edge<K, EV>> out) {
 			out.collect(edge);
 		}
 	}
     
-    private static final class ProjectVertexOnly<K, VV> implements FlatJoinFunction<
-    	Tuple1<K>,Tuple2<K,VV>, Tuple2<K,VV>> {
-		public void join(Tuple1<K> vertexId, Tuple2<K, VV> vertex,
-				Collector<Tuple2<K, VV>> out) {
+    private static final class ProjectVertexOnly<K extends Comparable<K> & Serializable, 
+		VV extends Serializable> implements FlatJoinFunction<
+    	Tuple1<K>, Vertex<K,VV>, Vertex<K,VV>> {
+		public void join(Tuple1<K> vertexId, Vertex<K, VV> vertex,
+				Collector<Vertex<K, VV>> out) {
 			out.collect(vertex);
 		}
     }
     
-    private static final class SelectVertex<K, VV> implements FilterFunction<Tuple2<K, VV>> {
+    private static final class SelectVertex<K extends Comparable<K> & Serializable, 
+    	VV extends Serializable> implements FilterFunction<Vertex<K, VV>> {
     	private K vertexId;
     	
     	private SelectVertex(K srcId) {
     		this.vertexId = srcId;
     	}
 
-    	public boolean filter(Tuple2<K, VV> vertex) throws Exception {
+    	public boolean filter(Vertex<K, VV> vertex) throws Exception {
 			return (vertex.f0.equals(vertexId));
 		}
 	} 

--- a/src/test/java/flink/graphs/TestGetDeltaNeighborhoodGraph.java
+++ b/src/test/java/flink/graphs/TestGetDeltaNeighborhoodGraph.java
@@ -12,7 +12,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 @RunWith(Parameterized.class)
-public class TestGetNeighborhoodGraph extends JavaProgramTestBase {
+public class TestGetDeltaNeighborhoodGraph extends JavaProgramTestBase {
 
     private static int NUM_PROGRAMS = 7;
 
@@ -20,7 +20,7 @@ public class TestGetNeighborhoodGraph extends JavaProgramTestBase {
     private String resultPath;
     private String expectedResult;
 
-    public TestGetNeighborhoodGraph(Configuration config) {
+    public TestGetDeltaNeighborhoodGraph(Configuration config) {
         super(config);
     }
 
@@ -69,7 +69,7 @@ public class TestGetNeighborhoodGraph extends JavaProgramTestBase {
                     Graph<Long, Long, Long> graph = Graph.create(TestGraphUtils.getLongLongVertexData(env),
                             TestGraphUtils.getLongLongEdgeData(env), env);
 
-                    graph.getNeighborhoodGraph(1L, 1).getVertexIds().writeAsText(resultPath);
+                    graph.getDeltaNeighborhoodGraph(1L, 1).getVertexIds().writeAsText(resultPath);
                     env.execute();
                     return "1\n" +
                             "2\n" +
@@ -85,7 +85,7 @@ public class TestGetNeighborhoodGraph extends JavaProgramTestBase {
                         Graph<Long, Long, Long> graph = Graph.create(TestGraphUtils.getLongLongVertexData(env),
                                 TestGraphUtils.getLongLongEdgeData(env), env);
 
-                        graph.getNeighborhoodGraph(1L, 2).getVertexIds().writeAsText(resultPath);
+                        graph.getDeltaNeighborhoodGraph(1L, 2).getVertexIds().writeAsText(resultPath);
                         env.execute();
                         return "1\n" +
                                 "2\n" +
@@ -102,7 +102,7 @@ public class TestGetNeighborhoodGraph extends JavaProgramTestBase {
                         Graph<Long, Long, Long> graph = Graph.create(TestGraphUtils.getLongLongVertexData(env),
                                 TestGraphUtils.getLongLongEdgeData(env), env);
 
-                        graph.getNeighborhoodGraph(1L, 1).getEdgeIds().writeAsCsv(resultPath);
+                        graph.getDeltaNeighborhoodGraph(1L, 1).getEdgeIds().writeAsCsv(resultPath);
                         env.execute();
                         return "1,2\n" +
                                 "1,3\n" +
@@ -117,7 +117,7 @@ public class TestGetNeighborhoodGraph extends JavaProgramTestBase {
                         Graph<Long, Long, Long> graph = Graph.create(TestGraphUtils.getLongLongVertexData(env),
                                 TestGraphUtils.getLongLongEdgeData(env), env);
 
-                        graph.getNeighborhoodGraph(1L, 2).getEdgeIds().writeAsCsv(resultPath);
+                        graph.getDeltaNeighborhoodGraph(1L, 2).getEdgeIds().writeAsCsv(resultPath);
                         env.execute();
                         return "1,2\n" +
                         		"1,3\n" +
@@ -137,7 +137,7 @@ public class TestGetNeighborhoodGraph extends JavaProgramTestBase {
                         		TestGraphUtils.getMoreLongLongEdgeData(env),
                         		env);
 
-                        graph.getNeighborhoodGraph(1L, 2).getEdgeIds().writeAsCsv(resultPath);
+                        graph.getDeltaNeighborhoodGraph(1L, 2).getEdgeIds().writeAsCsv(resultPath);
                         env.execute();
                         return "1,2\n" +
                         		"1,3\n" +
@@ -159,7 +159,7 @@ public class TestGetNeighborhoodGraph extends JavaProgramTestBase {
                         		TestGraphUtils.getMoreLongLongEdgeData(env),
                         		env);
 
-                        graph.getNeighborhoodGraph(1L, 2).getVertexIds().writeAsText(resultPath);
+                        graph.getDeltaNeighborhoodGraph(1L, 2).getVertexIds().writeAsText(resultPath);
                         env.execute();
                         return "1\n" +
 		                        "2\n" +
@@ -179,7 +179,7 @@ public class TestGetNeighborhoodGraph extends JavaProgramTestBase {
                         		TestGraphUtils.getMoreLongLongEdgeData(env),
                         		env);
 
-                        graph.getNeighborhoodGraph(1L, 3).getEdgeIds().writeAsCsv(resultPath);
+                        graph.getDeltaNeighborhoodGraph(1L, 3).getEdgeIds().writeAsCsv(resultPath);
                         env.execute();
                         return "1,2\n" +
                         		"1,3\n" +

--- a/src/test/java/flink/graphs/TestGetNeighborhoodGraph.java
+++ b/src/test/java/flink/graphs/TestGetNeighborhoodGraph.java
@@ -1,0 +1,108 @@
+package flink.graphs;
+
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.test.util.JavaProgramTestBase;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+
+@RunWith(Parameterized.class)
+public class TestGetNeighborhoodGraph extends JavaProgramTestBase {
+
+    private static int NUM_PROGRAMS = 2;
+
+    private int curProgId = config.getInteger("ProgramId", -1);
+    private String resultPath;
+    private String expectedResult;
+
+    public TestGetNeighborhoodGraph(Configuration config) {
+        super(config);
+    }
+
+    @Override
+    protected void preSubmit() throws Exception {
+        resultPath = getTempDirPath("result");
+    }
+
+    @Override
+    protected void testProgram() throws Exception {
+        expectedResult = GraphProgs.runProgram(curProgId, resultPath);
+    }
+
+    @Override
+    protected void postSubmit() throws Exception {
+        compareResultsByLinesInMemory(expectedResult, resultPath);
+    }
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> getConfigurations() throws FileNotFoundException, IOException {
+
+        LinkedList<Configuration> tConfigs = new LinkedList<Configuration>();
+
+        for(int i=1; i <= NUM_PROGRAMS; i++) {
+            Configuration config = new Configuration();
+            config.setInteger("ProgramId", i);
+            tConfigs.add(config);
+        }
+
+        return toParameterList(tConfigs);
+    }
+
+    private static class GraphProgs {
+
+        public static String runProgram(int progId, String resultPath) throws Exception {
+
+            switch (progId) {
+                case 1: {
+				/*
+				 * Test getNeighborhood with 1 step
+				 */
+                    final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+                    Graph<Long, Long, Long> graph = Graph.create(TestGraphUtils.getLongLongVertexData(env),
+                            TestGraphUtils.getLongLongEdgeData(env), env);
+
+                    graph.getNeighborhoodGraph(1L, 1).getVertexIds().writeAsText(resultPath);
+                    env.execute();
+                    return "1\n" +
+                            "2\n" +
+                            "3\n" +
+                            "5\n";
+                }
+                case 2: {
+                	/*
+    				 * Test getNeighborhood with 2 steps
+    				 */
+                        final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+                        Graph<Long, Long, Long> graph = Graph.create(TestGraphUtils.getLongLongVertexData(env),
+                                TestGraphUtils.getLongLongEdgeData(env), env);
+
+                        graph.getNeighborhoodGraph(1L, 2).getVertexIds().writeAsText(resultPath);
+                        env.execute();
+                        return "1\n" +
+                                "2\n" +
+                                "3\n" +
+                                "4\n" +
+                                "5\n";
+                }
+                case 3: {
+                }
+                case 4: {
+                }
+                case 5: {
+                }
+                case 6: {
+                }
+                default:
+                    throw new IllegalArgumentException("Invalid program id");
+
+            }
+        }
+    }
+}

--- a/src/test/java/flink/graphs/TestGraphUtils.java
+++ b/src/test/java/flink/graphs/TestGraphUtils.java
@@ -35,38 +35,38 @@ public class TestGraphUtils {
 		return env.fromCollection(edges);
 	}
 	
-	public static final DataSet<Tuple2<Long, Long>> getMoreLongLongVertexData(
+	public static final DataSet<Vertex<Long, Long>> getMoreLongLongVertexData(
 			ExecutionEnvironment env) {
-		List<Tuple2<Long, Long>> vertices = new ArrayList<Tuple2<Long, Long>>();
-		vertices.add(new Tuple2<Long, Long>(1L, 1L));
-		vertices.add(new Tuple2<Long, Long>(2L, 2L));
-		vertices.add(new Tuple2<Long, Long>(3L, 3L));
-		vertices.add(new Tuple2<Long, Long>(4L, 4L));
-		vertices.add(new Tuple2<Long, Long>(5L, 5L));
-		vertices.add(new Tuple2<Long, Long>(6L, 6L));
-		vertices.add(new Tuple2<Long, Long>(7L, 7L));
-		vertices.add(new Tuple2<Long, Long>(8L, 8L));
-		vertices.add(new Tuple2<Long, Long>(9L, 9L));
+		List<Vertex<Long, Long>> vertices = new ArrayList<Vertex<Long, Long>>();
+		vertices.add(new Vertex<Long, Long>(1L, 1L));
+		vertices.add(new Vertex<Long, Long>(2L, 2L));
+		vertices.add(new Vertex<Long, Long>(3L, 3L));
+		vertices.add(new Vertex<Long, Long>(4L, 4L));
+		vertices.add(new Vertex<Long, Long>(5L, 5L));
+		vertices.add(new Vertex<Long, Long>(6L, 6L));
+		vertices.add(new Vertex<Long, Long>(7L, 7L));
+		vertices.add(new Vertex<Long, Long>(8L, 8L));
+		vertices.add(new Vertex<Long, Long>(9L, 9L));
 		
 		return env.fromCollection(vertices);
 	}
 	
-	public static final DataSet<Tuple3<Long, Long, Long>> getMoreLongLongEdgeData(
+	public static final DataSet<Edge<Long, Long>> getMoreLongLongEdgeData(
 			ExecutionEnvironment env) {
-		List<Tuple3<Long, Long, Long>> edges = new ArrayList<Tuple3<Long, Long, Long>>();
-		edges.add(new Tuple3<Long,Long, Long>(1L, 2L, 12L));
-		edges.add(new Tuple3<Long,Long, Long>(1L, 3L, 13L));
-		edges.add(new Tuple3<Long,Long, Long>(2L, 3L, 23L));
-		edges.add(new Tuple3<Long,Long, Long>(3L, 4L, 34L));
-		edges.add(new Tuple3<Long,Long, Long>(3L, 5L, 35L));
-		edges.add(new Tuple3<Long,Long, Long>(4L, 5L, 45L));
-		edges.add(new Tuple3<Long,Long, Long>(5L, 1L, 51L));
+		List<Edge<Long, Long>> edges = new ArrayList<Edge<Long, Long>>();
+		edges.add(new Edge<Long, Long>(1L, 2L, 12L));
+		edges.add(new Edge<Long, Long>(1L, 3L, 13L));
+		edges.add(new Edge<Long, Long>(2L, 3L, 23L));
+		edges.add(new Edge<Long, Long>(3L, 4L, 34L));
+		edges.add(new Edge<Long, Long>(3L, 5L, 35L));
+		edges.add(new Edge<Long, Long>(4L, 5L, 45L));
+		edges.add(new Edge<Long, Long>(5L, 1L, 51L));
 
-		edges.add(new Tuple3<Long,Long, Long>(5L, 6L, 56L));
-		edges.add(new Tuple3<Long,Long, Long>(6L, 7L, 67L));
-		edges.add(new Tuple3<Long,Long, Long>(7L, 5L, 75L));
-		edges.add(new Tuple3<Long,Long, Long>(4L, 8L, 48L));
-		edges.add(new Tuple3<Long,Long, Long>(4L, 9L, 49L));
+		edges.add(new Edge<Long, Long>(5L, 6L, 56L));
+		edges.add(new Edge<Long, Long>(6L, 7L, 67L));
+		edges.add(new Edge<Long, Long>(7L, 5L, 75L));
+		edges.add(new Edge<Long, Long>(4L, 8L, 48L));
+		edges.add(new Edge<Long, Long>(4L, 9L, 49L));
 		
 		return env.fromCollection(edges);
 	}

--- a/src/test/java/flink/graphs/TestGraphUtils.java
+++ b/src/test/java/flink/graphs/TestGraphUtils.java
@@ -34,6 +34,42 @@ public class TestGraphUtils {
 		
 		return env.fromCollection(edges);
 	}
+	
+	public static final DataSet<Tuple2<Long, Long>> getMoreLongLongVertexData(
+			ExecutionEnvironment env) {
+		List<Tuple2<Long, Long>> vertices = new ArrayList<Tuple2<Long, Long>>();
+		vertices.add(new Tuple2<Long, Long>(1L, 1L));
+		vertices.add(new Tuple2<Long, Long>(2L, 2L));
+		vertices.add(new Tuple2<Long, Long>(3L, 3L));
+		vertices.add(new Tuple2<Long, Long>(4L, 4L));
+		vertices.add(new Tuple2<Long, Long>(5L, 5L));
+		vertices.add(new Tuple2<Long, Long>(6L, 6L));
+		vertices.add(new Tuple2<Long, Long>(7L, 7L));
+		vertices.add(new Tuple2<Long, Long>(8L, 8L));
+		vertices.add(new Tuple2<Long, Long>(9L, 9L));
+		
+		return env.fromCollection(vertices);
+	}
+	
+	public static final DataSet<Tuple3<Long, Long, Long>> getMoreLongLongEdgeData(
+			ExecutionEnvironment env) {
+		List<Tuple3<Long, Long, Long>> edges = new ArrayList<Tuple3<Long, Long, Long>>();
+		edges.add(new Tuple3<Long,Long, Long>(1L, 2L, 12L));
+		edges.add(new Tuple3<Long,Long, Long>(1L, 3L, 13L));
+		edges.add(new Tuple3<Long,Long, Long>(2L, 3L, 23L));
+		edges.add(new Tuple3<Long,Long, Long>(3L, 4L, 34L));
+		edges.add(new Tuple3<Long,Long, Long>(3L, 5L, 35L));
+		edges.add(new Tuple3<Long,Long, Long>(4L, 5L, 45L));
+		edges.add(new Tuple3<Long,Long, Long>(5L, 1L, 51L));
+
+		edges.add(new Tuple3<Long,Long, Long>(5L, 6L, 56L));
+		edges.add(new Tuple3<Long,Long, Long>(6L, 7L, 67L));
+		edges.add(new Tuple3<Long,Long, Long>(7L, 5L, 75L));
+		edges.add(new Tuple3<Long,Long, Long>(4L, 8L, 48L));
+		edges.add(new Tuple3<Long,Long, Long>(4L, 9L, 49L));
+		
+		return env.fromCollection(edges);
+	}
 
 	/**
 	 * A graph that has at least one vertex with no ingoing/outgoing edges


### PR DESCRIPTION
Hi,

I gave a try at the getNeighboorhoodGraph method and ended up with two implementations, one using a bulk iteration and one using a delta iteration. Look at the `getNeighborhoodGraph` and `getDeltaNeighborhoodGraph` methods. 
The main difference between the two is that, when using a delta iteration, you can add in the workset only the new vertices you discover in each iteration. However, in order to compute that, I have to compare with the previous workset and create the difference, which is not so efficient.
So, I'm not sure which one of the two to keep. Any clues?

Also,  I added a `getNeighbors(VertexID)` method in the Graph class, which returns the neighbors of the given vertex in a Dataset. This would be a simpler (or alternative) way to deal with #18.
