### PR TITLE
Splitted runVertexCentricIteration into createVertexCentricIteration and runVertexCentricIteration

### DIFF
--- a/src/main/java/flink/graphs/Graph.java
+++ b/src/main/java/flink/graphs/Graph.java
@@ -1105,20 +1105,30 @@ public class Graph<K extends Comparable<K> & Serializable, VV extends Serializab
         DataSet<Edge<K,EV>> unionedEdges = graph.getEdges().union(this.getEdges());
         return new Graph<K,VV,EV>(unionedVertices, unionedEdges, this.context);
     }
+    
+    /**
+     * Returns a Vertex-Centric iteration object.
+     * @param vertexUpdateFunction the vertex update function
+     * @param messagingFunction the messaging function
+     * @param maximumNumberOfIterations maximum number of iterations to perform
+     * @return
+     */
+    public <M> VertexCentricIteration<K, VV, M, EV> createVertexCentricIteration(
+            VertexUpdateFunction<K, VV, M> vertexUpdateFunction,
+            MessagingFunction<K, VV, M, EV> messagingFunction,
+            int maximumNumberOfIterations) {
+        return VertexCentricIteration.withEdges(edges, vertexUpdateFunction,
+                messagingFunction, maximumNumberOfIterations);
+    }
 
-	/**
-	 * Runs a Vertex-Centric iteration on the graph.
-	 * @param vertexUpdateFunction the vertex update function
-	 * @param messagingFunction the messaging function
-	 * @param maximumNumberOfIterations maximum number of iterations to perform
-	 * @return
-	 */
-	public <M>Graph<K, VV, EV> runVertexCentricIteration(VertexUpdateFunction<K, VV, M> vertexUpdateFunction,
-    		MessagingFunction<K, VV, M, EV> messagingFunction, int maximumNumberOfIterations) {
-    	DataSet<Vertex<K, VV>> newVertices = vertices.runOperation(
-    	                     VertexCentricIteration.withEdges(edges,
-						vertexUpdateFunction, messagingFunction, maximumNumberOfIterations));
-		return new Graph<K, VV, EV>(newVertices, this.edges, this.context);
+    /**
+     * Runs a Vertex-Centric iteration on the graph.
+     * @param iteration the Vertex-Centric iteration object to run  
+     * @return
+     */
+    public <M>Graph<K, VV, EV> runVertexCentricIteration(VertexCentricIteration<K, VV, M, EV> iteration) {
+        DataSet<Vertex<K, VV>> newVertices = vertices.runOperation(iteration);
+        return new Graph<K, VV, EV>(newVertices, this.edges, this.context);
     }
 
 	public Graph<K, VV, EV> run (GraphAlgorithm<K, VV, EV> algorithm) {

--- a/src/main/java/flink/graphs/library/LabelPropagation.java
+++ b/src/main/java/flink/graphs/library/LabelPropagation.java
@@ -3,6 +3,7 @@ package flink.graphs.library;
 import flink.graphs.*;
 import flink.graphs.spargel.MessageIterator;
 import flink.graphs.spargel.MessagingFunction;
+import flink.graphs.spargel.VertexCentricIteration;
 import flink.graphs.spargel.VertexUpdateFunction;
 
 import org.apache.flink.types.NullValue;
@@ -35,11 +36,13 @@ public class LabelPropagation<K extends Comparable<K> & Serializable> implements
 
     	// iteratively adopt the most frequent label among the neighbors
     	// of each vertex
-    	return input.runVertexCentricIteration(
+        VertexCentricIteration<K, Long, Long, NullValue> iteration = input.createVertexCentricIteration(
                 new UpdateVertexLabel<K>(),
                 new SendNewLabelToNeighbors<K>(),
                 maxIterations
         );
+        
+        return input.runVertexCentricIteration(iteration);
     }
 
     /**

--- a/src/main/java/flink/graphs/library/PageRank.java
+++ b/src/main/java/flink/graphs/library/PageRank.java
@@ -5,6 +5,7 @@ import flink.graphs.Graph;
 import flink.graphs.GraphAlgorithm;
 import flink.graphs.spargel.MessageIterator;
 import flink.graphs.spargel.MessagingFunction;
+import flink.graphs.spargel.VertexCentricIteration;
 import flink.graphs.spargel.VertexUpdateFunction;
 
 import java.io.Serializable;
@@ -23,11 +24,13 @@ public class PageRank<K extends Comparable<K> & Serializable> implements GraphAl
 
     @Override
     public Graph<K, Double, Double> run(Graph<K, Double, Double> network) {
-        return network.runVertexCentricIteration(
+        VertexCentricIteration<K, Double, Double, Double> iteration =  network.createVertexCentricIteration(
                 new VertexRankUpdater<K>(numVertices, beta),
                 new RankMessenger<K>(),
                 maxIterations
         );
+        
+        return network.runVertexCentricIteration(iteration);
     }
 
 

--- a/src/main/java/flink/graphs/library/SingleSourceShortestPaths.java
+++ b/src/main/java/flink/graphs/library/SingleSourceShortestPaths.java
@@ -3,6 +3,7 @@ package flink.graphs.library;
 import flink.graphs.*;
 import flink.graphs.spargel.MessageIterator;
 import flink.graphs.spargel.MessagingFunction;
+import flink.graphs.spargel.VertexCentricIteration;
 import flink.graphs.spargel.VertexUpdateFunction;
 
 import org.apache.flink.api.common.functions.MapFunction;
@@ -23,12 +24,12 @@ public class SingleSourceShortestPaths<K extends Comparable<K> & Serializable> i
     @Override
     public Graph<K, Double, Double> run(Graph<K, Double, Double> input) {
 
-    	return input.mapVertices(new InitVerticesMapper<K>(srcVertexId))
-    			.runVertexCentricIteration(
-                new VertexDistanceUpdater<K>(),
-                new MinDistanceMessenger<K>(),
-                maxIterations
-        );
+        VertexCentricIteration<K, Double, Double, Double> iteration = input
+                .mapVertices(new InitVerticesMapper<K>(srcVertexId))
+                .createVertexCentricIteration(new VertexDistanceUpdater<K>(),
+                        new MinDistanceMessenger<K>(), maxIterations);
+        
+        return input.runVertexCentricIteration(iteration);
     }
 
     public static final class InitVerticesMapper<K extends Comparable<K> & Serializable> 


### PR DESCRIPTION
I changed the process for running a vertex-centric iteration into a two-step procedure:
1. `createVertexCentricIteration` returns a `VertexCentricIteration` object to allow developers to access features like broadcast data sets and  aggregators.
2. `runVertexCentricIteration` expects a `VertexCentricIteration` and returns the `Graph`.